### PR TITLE
Replace some custom date/time formatting

### DIFF
--- a/TransferWindowPlanner/FrameworkExt/KSPDateStructure.cs
+++ b/TransferWindowPlanner/FrameworkExt/KSPDateStructure.cs
@@ -17,34 +17,32 @@ namespace KSPPluginFramework
         static public Int32 EpochDayOfYear { get; private set; }
         /// <summary>What Year does UT 0 represent</summary>
         static public Int32 EpochYear { get; private set; }
-
-
+        
         static public KSPDateTime EpochAsKSPDateTime { 
             get {
                 return new KSPDateTime(EpochYear, EpochDayOfYear);
             }
         }
-
-
+        
         //Define the Calendar
         /// <summary>How many seconds (game UT) make up a minute</summary>
         static public Int32 SecondsPerMinute { get; private set; }
         /// <summary>How many minutes make up an hour</summary>
         static public Int32 MinutesPerHour { get; private set; }
         /// <summary>How many hours make up a day</summary>
-        static public Int32 HoursPerDay { get; private set; }
+        static public double HoursPerDay { get; private set; }
         /// <summary>How many days make up a year</summary>
-        static public Int32 DaysPerYear { get; private set; }
+        static public double DaysPerYear { get; private set; }
 
         /// <summary>How many seconds (game UT) make up an hour</summary>
         static public Int32 SecondsPerHour { get { return SecondsPerMinute * MinutesPerHour; } }
         /// <summary>How many seconds (game UT) make up a day</summary>
-        static public Int32 SecondsPerDay { get { return SecondsPerHour * HoursPerDay; } }
+        static public double SecondsPerDay { get { return SecondsPerHour * HoursPerDay; } }
         /// <summary>How many seconds (game UT) make up a year - not relevant for Earth time</summary>
-        static public Int32 SecondsPerYear { get { return SecondsPerDay * DaysPerYear; } }
+        static public double SecondsPerYear { get { return SecondsPerDay * DaysPerYear; } }
 
         /// <summary>How many seconds (game UT) make up a year - not relevant for Earth time</summary>
-        static public Int32 HoursPerYear { get { return HoursPerDay * DaysPerYear; } }
+        static public double HoursPerYear { get { return HoursPerDay * DaysPerYear; } }
 
         
         /// <summary>What Earth date does UT 0 represent</summary>
@@ -63,8 +61,8 @@ namespace KSPPluginFramework
             SecondsPerMinute = 60;
             MinutesPerHour = 60;
 
-            HoursPerDay = GameSettings.KERBIN_TIME ? 6 : 24;
-            DaysPerYear = GameSettings.KERBIN_TIME ? 426 : 365;
+            HoursPerDay = KSPUtil.dateTimeFormatter.Day / 3600; // GameSettings.KERBIN_TIME ? 6 : 24;
+            DaysPerYear = KSPUtil.dateTimeFormatter.Year / KSPUtil.dateTimeFormatter.Day; // GameSettings.KERBIN_TIME ? 426 : 365;
         }
 
         /// <summary>Sets the Date Structure to be Earth based - Accepts Epoch date as string</summary>

--- a/TransferWindowPlanner/FrameworkExt/KSPDateTime.cs
+++ b/TransferWindowPlanner/FrameworkExt/KSPDateTime.cs
@@ -184,7 +184,7 @@ namespace KSPPluginFramework
 		{
 			//Test for entering values outside the norm - eg 25 hours, day 600
 
-			UT = new KSPTimeSpan((year - KSPDateStructure.EpochYear) * KSPDateStructure.DaysPerYear  +
+			UT = new KSPTimeSpan((Int32)((year - KSPDateStructure.EpochYear) * KSPDateStructure.DaysPerYear)  +
 								(day - KSPDateStructure.EpochDayOfYear),
 								hour,
 								minute,
@@ -261,12 +261,12 @@ namespace KSPPluginFramework
 				case DateStringFormatsEnum.KSPFormat:
 					return ToString();
 				case DateStringFormatsEnum.KSPFormatWithSecs:
-					return ToString("Year y, Da\\y d - H\\h, m\\m, s\\s");
+					return KSPUtil.dateTimeFormatter.PrintDate(UT, true, true); // ToString("Year y, Da\\y d - H\\h, m\\m, s\\s");
 				case DateStringFormatsEnum.DateTimeFormat:
                     if (KSPDateStructure.CalendarType==CalendarTypeEnum.Earth)
                         return ToString("d MMM yyyy, HH:mm:ss");
                     else
-					    return ToString("Year y, Da\\y d, HH:mm:ss");
+					    return KSPUtil.dateTimeFormatter.PrintDateCompact(UT, true, true); // ToString("Year y, Da\\y d, HH:mm:ss");
 				default:
 					return ToString();
 			}
@@ -279,7 +279,7 @@ namespace KSPPluginFramework
 			if (CalType ==CalendarTypeEnum.Earth) {
 				return ToString(System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern);
 			} else {
-				return ToString("Year y, Da\\y d - H\\h, m\\m", null);
+                return KSPUtil.dateTimeFormatter.PrintDate(UT, true, false); // ToString("Year y, Da\\y d - H\\h, m\\m", null);
 			}
 		}
 		/// <summary>Returns the string representation of the value of this instance.</summary> 

--- a/TransferWindowPlanner/FrameworkExt/KSPTimeSpan.cs
+++ b/TransferWindowPlanner/FrameworkExt/KSPTimeSpan.cs
@@ -64,7 +64,7 @@ namespace KSPPluginFramework
         /// The minute component of the current KSPPluginFramework.KSPTimeSpan structure. The return value ranges between +/- <see cref="KSPDateStructure.MinutesPerHour"/>
         /// </returns>
         public int Minutes {
-            get { return (Int32)(UT / KSPDateStructure.SecondsPerMinute % KSPDateStructure.MinutesPerHour); }
+            get { return (Int32)UT / KSPDateStructure.SecondsPerMinute % KSPDateStructure.MinutesPerHour; }
         }
 
         /// <summary>Gets the seconds component of the time interval represented by the current KSPPluginFramework.KSPTimeSpan structure.</summary> 
@@ -72,7 +72,7 @@ namespace KSPPluginFramework
         /// The second component of the current KSPPluginFramework.KSPTimeSpan structure. The return value ranges between +/- <see cref="KSPDateStructure.SecondsPerMinute"/>
         /// </returns>
         public int Seconds {
-            get { return (Int32)(UT % KSPDateStructure.SecondsPerMinute); }
+            get { return (Int32)UT % KSPDateStructure.SecondsPerMinute; }
         }
 
         /// <summary>Gets the milliseconds component of the time interval represented by the current KSPPluginFramework.KSPTimeSpan structure.</summary> 
@@ -130,10 +130,10 @@ namespace KSPPluginFramework
         /// <param name="milliseconds">Number of milliseconds.</param>
         public KSPTimeSpan(int days, int hours, int minutes, int seconds, int milliseconds)
         {
-            UT = (Double)days * KSPDateStructure.SecondsPerDay +
-                 (Double)hours * KSPDateStructure.SecondsPerHour +
-                 (Double)minutes * KSPDateStructure.SecondsPerMinute +
-                 (Double)seconds +
+            UT = days * KSPDateStructure.SecondsPerDay +
+                 hours * KSPDateStructure.SecondsPerHour +
+                 minutes * KSPDateStructure.SecondsPerMinute +
+                 seconds +
                 (Double)milliseconds / 1000;
         }
 
@@ -183,19 +183,20 @@ namespace KSPPluginFramework
                 case TimeSpanStringFormatsEnum.DateTimeFormat:
                     return ToDateTimeString(Precision);
                 case TimeSpanStringFormatsEnum.IntervalLong:
-                    return ToString((UT < 0?"+ ":"") + "y Year\\s, d Da\\y\\s, hh:mm:ss");
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintTimeLong(UT); // ToString((UT < 0?"+ ":"") + "y Year\\s, d Da\\y\\s, hh:mm:ss");
                 case TimeSpanStringFormatsEnum.IntervalLongTrimYears:
-                    return ToString((UT < 0 ? "+ " : "") + "y Year\\s, d Da\\y\\s, hh:mm:ss").Replace("0 Years, ", "");
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintTimeLong(UT); // ToString((UT < 0 ? "+ " : "") + "y Year\\s, d Da\\y\\s, hh:mm:ss").Replace("0 Years, ", "");
                 case TimeSpanStringFormatsEnum.DateTimeFormatLong:
-                    String strFormat = "";
-                    if (Years > 0) strFormat += "y\\y";
-                    if (Days > 0) strFormat += (strFormat.EndsWith("y") ? ", ":"") + "d\\d";
-                    if (strFormat!="") strFormat += " ";
-                    strFormat += "hh:mm:ss";
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, true, true, true);
+                //String strFormat = "";
+                //if (Years > 0) strFormat += "y\\y";
+                //if (Days > 0) strFormat += (strFormat.EndsWith("y") ? ", ":"") + "d\\d";
+                //if (strFormat!="") strFormat += " ";
+                //strFormat += "hh:mm:ss";
 
-                    if (UT < 0) strFormat = "+ " + strFormat;
+                //if (UT < 0) strFormat = "+ " + strFormat;
 
-                    return ToString(strFormat);
+                //return ToString(strFormat);
                 default:
                     return ToString();
             }
@@ -213,45 +214,47 @@ namespace KSPPluginFramework
         /// <returns>A string that represents the value of this instance.</returns>
         public String ToString(Int32 Precision)
         {
-            Int32 Displayed = 0;
-            String format = "";
+            return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, Precision > 2, Precision >= 5, true);
 
-            if (UT < 0) format += "+";
+            //Int32 Displayed = 0;
+            //String format = "";
+
+            //if (UT < 0) format += "+";
 
 
-            if (CalType != CalendarTypeEnum.Earth) {
-                if ((Years != 0) && Displayed < Precision) {
-                    format = "y\\y,";
-                    Displayed++;
-                }
-            }
+            //if (CalType != CalendarTypeEnum.Earth) {
+            //    if ((Years != 0) && Displayed < Precision) {
+            //        format = "y\\y,";
+            //        Displayed++;
+            //    }
+            //}
 
-            if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "d\\d,";
-                Displayed++;
-            }
-            if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format==""?"":" ") + "h\\h,";
-                Displayed++;
+            //if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "d\\d,";
+            //    Displayed++;
+            //}
+            //if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format==""?"":" ") + "h\\h,";
+            //    Displayed++;
 
-            }
-            if ((Minutes != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format==""?"":" ") + "m\\m,";
-                Displayed++;
+            //}
+            //if ((Minutes != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format==""?"":" ") + "m\\m,";
+            //    Displayed++;
 
-            }
-            if (Displayed<Precision) {
-                format += (format==""?"":" ") + "s\\s,";
-                Displayed++;
+            //}
+            //if (Displayed<Precision) {
+            //    format += (format==""?"":" ") + "s\\s,";
+            //    Displayed++;
 
-            }
+            //}
 
-            format = format.TrimEnd(',');
+            //format = format.TrimEnd(',');
 
-            return ToString(format, null);
+            //return ToString(format, null);
         }
 
         /// <summary>Returns the string representation of the value of this instance.</summary> 
@@ -259,48 +262,49 @@ namespace KSPPluginFramework
         /// <returns>A string that represents the value of this instance.</returns>
         public String ToDateTimeString(Int32 Precision)
         {
-            Int32 Displayed = 0;
-            String format = "";
+            return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, Precision > 2, Precision >= 5, true);
+            //Int32 Displayed = 0;
+            //String format = "";
 
-            if (UT < 0) format += "+ ";
+            //if (UT < 0) format += "+ ";
 
 
-            if (CalType != CalendarTypeEnum.Earth)
-            {
-                if ((Years != 0) && Displayed < Precision)
-                {
-                    format = "y\\y,";
-                    Displayed++;
-                }
-            }
+            //if (CalType != CalendarTypeEnum.Earth)
+            //{
+            //    if ((Years != 0) && Displayed < Precision)
+            //    {
+            //        format = "y\\y,";
+            //        Displayed++;
+            //    }
+            //}
 
-            if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "d\\d,";
-                Displayed++;
-            }
-            if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "hh:";
-                Displayed++;
+            //if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "d\\d,";
+            //    Displayed++;
+            //}
+            //if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "hh:";
+            //    Displayed++;
 
-            }
-            if (Displayed < Precision)
-            {
-                format += "mm:";
-                Displayed++;
+            //}
+            //if (Displayed < Precision)
+            //{
+            //    format += "mm:";
+            //    Displayed++;
 
-            }
-            if (Displayed < Precision)
-            {
-                format += "ss";
-                Displayed++;
+            //}
+            //if (Displayed < Precision)
+            //{
+            //    format += "ss";
+            //    Displayed++;
 
-            }
+            //}
 
-            format = format.TrimEnd(',').TrimEnd(':');
+            //format = format.TrimEnd(',').TrimEnd(':');
 
-            return ToString(format, null);
+            //return ToString(format, null);
         }
 
         /// <summary>Returns the string representation of the value of this instance.</summary> 

--- a/TransferWindowPlanner/TWPWindowSettings.cs
+++ b/TransferWindowPlanner/TWPWindowSettings.cs
@@ -43,13 +43,13 @@ namespace TransferWindowPlanner
 
             TooltipMouseOffset = new Vector2d(-10, 10);
 
-            ddlSettingsTab = new DropDownList(EnumExtensions.ToEnumDescriptions<SettingsTabs>(), this);
+            ddlSettingsTab = new DropDownList(KSPPluginFramework.EnumExtensions.ToEnumDescriptions<SettingsTabs>(), this);
 
-            ddlSettingsSkin = new DropDownList(EnumExtensions.ToEnumDescriptions<Settings.DisplaySkin>(), (Int32)settings.SelectedSkin, this);
+            ddlSettingsSkin = new DropDownList(KSPPluginFramework.EnumExtensions.ToEnumDescriptions<Settings.DisplaySkin>(), (Int32)settings.SelectedSkin, this);
             ddlSettingsSkin.OnSelectionChanged += ddlSettingsSkin_SelectionChanged;
-            ddlSettingsButtonStyle = new DropDownList(EnumExtensions.ToEnumDescriptions<Settings.ButtonStyleEnum>(), (Int32)settings.ButtonStyleChosen, this);
+            ddlSettingsButtonStyle = new DropDownList(KSPPluginFramework.EnumExtensions.ToEnumDescriptions<Settings.ButtonStyleEnum>(), (Int32)settings.ButtonStyleChosen, this);
             ddlSettingsButtonStyle.OnSelectionChanged += ddlSettingsButtonStyle_OnSelectionChanged;
-            ddlSettingsCalendar = new DropDownList(EnumExtensions.ToEnumDescriptions<CalendarTypeEnum>(), this);
+            ddlSettingsCalendar = new DropDownList(KSPPluginFramework.EnumExtensions.ToEnumDescriptions<CalendarTypeEnum>(), this);
             //NOTE:Pull out the custom option for now
             ddlSettingsCalendar.Items.Remove(CalendarTypeEnum.Custom.Description());
             ddlSettingsCalendar.OnSelectionChanged += ddlSettingsCalendar_OnSelectionChanged;


### PR DESCRIPTION
To help support non-standard day/year lengths from custom planet packs
or system rescales, prefer use of KSPUtil.dateTimeFormatter.

Same date/time class changes as in [KAC#196](https://github.com/TriggerAu/KerbalAlarmClock/pull/196)

No issues noted during testing.

Compiled DLL: [TransferWindowPlanner.zip](https://github.com/TriggerAu/TransferWindowPlanner/files/1584950/TransferWindowPlanner.zip)
